### PR TITLE
Set session expiration to 1 week

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,6 @@
 
 <!-- A summary of the changes -->
 
-Switches the MCP Server architecture from an STDIO-based implementation to Streamable HTTP. This also required the server to be implemented as a Streamable HTTP server instead of an STDIO server.
-
 ## MCP Inspector QA
 
 1. Run `docker-compose up -d --build` to build the image and start the containers
@@ -11,3 +9,9 @@ Switches the MCP Server architecture from an STDIO-based implementation to Strea
 3. Click the link to open the MCP Inspector > Set URL to `http://osrs-mcp:3000/mcp`
 4. Click "Connect"
 5. _TODO_
+
+## Client QA
+
+1. Deploy your changes to Heroku.
+2. Connect (or re-connect) your Client to the deployed instance.
+3. _TODO_

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,7 +9,9 @@ origin that you push changes to.
 
 1. Install the `heroku` CLI.
 2. Run `heroku login`.
-3. Once logged in, push changes to the app via `git push heroku <branch>`
+3. Once logged in, push changes to the app via `git push heroku <branch>`.
+4. Wait for the build to run and ensure there were no errors.
+5. Test as-needed.
 
 ### Overriding branch changes
 You can push a branch's changes to another branch, overridding the changes there with whatever

--- a/src/proxy/routes/tokenPostHandler.ts
+++ b/src/proxy/routes/tokenPostHandler.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express';
 import { OAuthToken } from '../../types/auth';
-import { validatePKCE, generateSecureToken } from '../util/helpers';
+import { validatePKCE, generateSecureToken, setTokenExpiration } from '../util/helpers';
 import { authCodes, tokens, clients } from '../cache/inMemoryStore';
 
 // Token Endpoint
@@ -61,7 +61,7 @@ export const tokenPostHandler = (req: Request, res: Response) => {
 		const tokenData: OAuthToken = {
 			access_token,
 			token_type: 'Bearer',
-			expires_at: Date.now() + (60 * 60 * 1000), // 1 hour
+			expires_at: setTokenExpiration(0, 7),
 			client_id,
 			scope: authCode.scope,
 		};

--- a/src/proxy/util/helpers.ts
+++ b/src/proxy/util/helpers.ts
@@ -24,3 +24,10 @@ export function isValidRedirectUri(uri: string): boolean {
 		return false;
 	}
 }
+
+export const setTokenExpiration = (hours: number, days: number) => {
+	const oneHour = (60 * 60 * 1000)
+	const totalHours = oneHour * hours
+	const totalDays = (24 * oneHour) * days
+	return Date.now() + totalHours + totalDays
+}


### PR DESCRIPTION
# Summary

<!-- A summary of the changes -->

* Adds a helper method to easily alter the session duration
* Set duration to 1 week

## MCP Inspector QA

1. Run `docker-compose up -d --build` to build the image and start the containers
2. Open the Docker Logs > Locate the URL with the `MCP_PROXY_AUTH_TOKEN` appended at the end
3. Click the link to open the MCP Inspector > Set URL to `http://osrs-mcp:3000/mcp`
4. Click "Connect"
5. _TODO_

## Client QA

1. Deploy your changes to Heroku.
2. Connect (or re-connect) your Client to the deployed instance.
3. _TODO_
